### PR TITLE
ORT would crash after deleting one of the models and then doing an inference for v1.21.0

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
@@ -426,6 +426,12 @@ namespace Dml
     {
         ORT_TRY
         {
+
+        if (m_allocator)
+        {
+            m_context->SetAllocator(m_allocator);
+        }
+
         assert(!m_closed);
 
         DML_BINDING_DESC persistentResourceBindingDesc =


### PR DESCRIPTION
ORT would crash after deleting one of the models and then doing an inference for v1.21.0

Same as https://github.com/microsoft/onnxruntime/issues/22948


![image](https://github.com/user-attachments/assets/a6d1fbee-2e83-41b6-a602-998bbbd98e00)