### PR TITLE
Add session config_entry release_dynamic_resources to to release dynamic resources allocated when inference. for v1.21.0

### DIFF
--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -88,6 +88,8 @@ class IAllocator {
    */
   virtual void Free(void* p) = 0;
 
+  virtual void ReleaseDynamicResources() {};
+
   // Reserve() is an interface exposed for an implementation of IAllocator
   // to optionally implement some allocation logic that by-passes any arena-based
   // logic that may be housed in the Alloc() implementation.

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.cpp
@@ -81,6 +81,22 @@ namespace Dml
         return Alloc(size, m_defaultRoundingMode);
     }
 
+    void BucketizedBufferAllocator::ReleaseDynamicResources()
+    {
+        for (auto& bucket : m_pool)
+        {
+            if (bucket.resources.empty() == false)
+            {
+                for (auto& resource : bucket.resources)
+                {
+                    resource.resource = nullptr;
+                }
+            }
+            bucket.resources.clear();
+        }
+        m_pool.clear();
+    }
+
     void* BucketizedBufferAllocator::Alloc(size_t size, AllocatorRoundingMode roundingMode)
     {
         // For some reason lotus likes requesting 0 bytes of memory
@@ -170,7 +186,7 @@ namespace Dml
 
         // Free the resource to the pool if its size matches a bucket size
         gsl::index bucketIndex = GetBucketIndexFromSize(allocInfo->GetRequestedSize());
-        if (GetBucketSizeFromIndex(bucketIndex) == allocInfo->GetResource()->GetDesc().Width)
+        if (m_pool.size() > 0 && GetBucketSizeFromIndex(bucketIndex) == allocInfo->GetResource()->GetDesc().Width)
         {
             assert(gsl::narrow_cast<gsl::index>(m_pool.size()) > bucketIndex);
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.h
@@ -50,6 +50,7 @@ namespace Dml
         void* Alloc(size_t size, AllocatorRoundingMode roundingMode);
         void* Alloc(size_t size) final;
         void Free(void* p) final;
+        void ReleaseDynamicResources() override;
 
     private:
         static const uint32_t c_minResourceSizeExponent = 16; // 2^16 = 64KB

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2709,6 +2709,17 @@ Status InferenceSession::Run(const RunOptions& run_options,
                                      device_stream_collection_holder,
 #endif
                                      run_logger);
+
+        // handle release_dynamic_resources
+        std::string config_value = session_options_.config_options.GetConfigOrDefault("release_dynamic_resources", "0");
+        bool releaseDynamicResources = config_value == "true" || config_value == "1";
+
+        if (releaseDynamicResources)
+        {
+            auto pDevice = session_state_->GetExecutionProviders().Get(onnxruntime::kDmlExecutionProvider)->GetOrtDeviceByMemType(OrtMemTypeDefault);
+            auto allocator = session_state_->GetAllocator(pDevice);
+            allocator->ReleaseDynamicResources();
+        }
       }
 
       // info all execution providers InferenceSession:Run ended


### PR DESCRIPTION
Add session config_entry `release_dynamic_resources` to to release dynamic resources allocated when inference.

For example :

    session_options = onnxruntime.SessionOptions()
    session_options.add_session_config_entry("release_dynamic_resources", "1")
    vae_decoder     = load_model(MODEL_PATH, "vae_decoder", device_id=device_id, session_options=session_options)