### PR TITLE
[`v1.23.0` ]ORT would crash after deleting one of the models and then doing an inference

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
@@ -430,6 +430,12 @@ namespace Dml
     {
         ORT_TRY
         {
+
+        if (m_allocator)
+        {
+            m_context->SetAllocator(m_allocator);
+        }
+
         assert(!m_closed);
 
         DML_BINDING_DESC persistentResourceBindingDesc =


### PR DESCRIPTION
Cherry-pick 4785400