### PR TITLE
[‵v1.23.0`] Fix the release_dynamic_resources freezing issue when using IOBinding to run the session.

### DIFF
--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -167,6 +167,22 @@ void SessionState::UpdateAllocatorsWithEnvAllocators(const std::vector<Allocator
   }
 }
 
+void SessionState::TryReleaseDynamicResources() const {
+  std::string config_value = GetSessionOptions().config_options.GetConfigOrDefault("release_dynamic_resources", "0");
+  bool releaseDynamicResources = (config_value == "true") || (config_value == "1");
+
+  if (releaseDynamicResources) {
+    auto pDmlEp = GetExecutionProviders().Get(onnxruntime::kDmlExecutionProvider);
+    if (pDmlEp != nullptr) {
+      auto pDevice = pDmlEp->GetOrtDeviceByMemType(OrtMemTypeDefault);
+      auto allocator = GetAllocator(pDevice);
+      if (allocator != nullptr) {
+        allocator->ReleaseDynamicResources();
+      }
+    }
+  }
+}
+
 void SessionState::CreateGraphInfo(bool save_prepacked_on) {
   graph_.ConstructPrepackedSharedContainerAndSetMode(save_prepacked_on);
 

--- a/onnxruntime/core/framework/session_state.h
+++ b/onnxruntime/core/framework/session_state.h
@@ -141,6 +141,8 @@ class SessionState {
 
   void UpdateAllocatorsWithEnvAllocators(const std::vector<AllocatorPtr>&);
 
+  void TryReleaseDynamicResources() const;
+
   const OrtValueNameIdxMap& GetOrtValueNameIdxMap() const noexcept { return ort_value_name_idx_map_; }
 
   /**

--- a/onnxruntime/core/session/IOBinding.cc
+++ b/onnxruntime/core/session/IOBinding.cc
@@ -75,6 +75,9 @@ common::Status IOBinding::SynchronizeInputs() {
 
 common::Status IOBinding::SynchronizeOutputs() {
   ORT_RETURN_IF_ERROR(SyncProviders(session_state_.GetOutputNodeInfoMap(), session_state_));
+
+  session_state_.TryReleaseDynamicResources();
+
   return Status::OK();
 }
 

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -3281,7 +3281,12 @@ common::Status InferenceSession::RunAsync(const RunOptions* run_options,
 
 common::Status InferenceSession::Run(const NameMLValMap& feeds, gsl::span<const std::string> output_names,
                                      std::vector<OrtValue>* p_fetches) {
-  return Run(RunOptions(), feeds, output_names, p_fetches);
+  common::Status result = Run(RunOptions(), feeds, output_names, p_fetches);
+  if (result.IsOK()) {
+    this->session_state_->TryReleaseDynamicResources();
+  }
+
+  return result;
 }
 
 common::Status InferenceSession::Run(const RunOptions& run_options, const NameMLValMap& feeds_map,


### PR DESCRIPTION
[‵v1.23.0`] Fix the release_dynamic_resources freezing issue when using IOBinding to run the session.

cherry-pick  943c716
